### PR TITLE
chore: Use the new Equinor CDN

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -7,7 +7,7 @@ class MyDocument extends Document {
       <Html>
         <Head>
           <link
-            href="https://eds-static.equinor.com/font/equinor-font.css"
+            href="https://cdn.eds.equinor.com/font/equinor-font.css"
             rel="stylesheet"
           />
         </Head>

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -1,4 +1,4 @@
-@import "https://eds-static.equinor.com/font/equinor-font.css";
+@import "https://cdn.eds.equinor.com/font/equinor-font.css";
 
 // colors
 $equinor_PRIMARY: #ff1243;


### PR DESCRIPTION
Use the new Equinor CDN for getting the Equinor Font since the old CDN is getting removed.

Closes #534