### PR TITLE
feat: update delete choice/main activity warning text

### DIFF
--- a/components/DeleteNodeDialog.tsx
+++ b/components/DeleteNodeDialog.tsx
@@ -60,10 +60,10 @@ export function DeleteNodeDialog(props: {
   const header = `Delete ${getNodeTypeName(type).toLowerCase()}`;
 
   const getWarningMessage = () => {
-    if (type === mainActivity && hasChildren) {
-      return "This will delete all of its following cards.\nAre you sure you want to proceed?";
-    } else if (type === choice && hasChildren) {
-      return "This will delete all connected alternatives.\nAre you sure you want to proceed?";
+    const typeIsMainActivityOrChoice = type === mainActivity || type === choice;
+
+    if (typeIsMainActivityOrChoice && hasChildren) {
+      return "This will delete **ALL** the cards below.\nAre you sure you want to proceed?";
     }
     return "This will delete the selected card";
   };

--- a/components/ScrimDelete.tsx
+++ b/components/ScrimDelete.tsx
@@ -10,6 +10,7 @@ import {
 import { close as closeIcon, delete_forever } from "@equinor/eds-icons";
 import { ChangeEvent, useState } from "react";
 import styles from "./ScrimDelete.module.scss";
+import { TypographyMarkdown } from "./TypographyMarkdown";
 
 type ScrimDelete = {
   id: string;
@@ -62,7 +63,9 @@ export const ScrimDelete = ({
                   {unknownErrorToString(error)}
                 </Typography>
               )}
-              <Typography variant={"h4"}>{warningMessage}</Typography>
+              <TypographyMarkdown variant={"h4"}>
+                {warningMessage}
+              </TypographyMarkdown>
               {checkboxMessage && (
                 <Checkbox
                   label={checkboxMessage}

--- a/components/TypographyMarkdown.tsx
+++ b/components/TypographyMarkdown.tsx
@@ -1,0 +1,21 @@
+import { Typography, TypographyProps } from "@equinor/eds-core-react";
+import ReactMarkdown from "react-markdown";
+
+export type TypographyMarkdownProps = Omit<TypographyProps, "children"> & {
+  children?: string;
+};
+
+/**
+ * When you want to render markdown in a Typography component.
+ * `children` has to be a string (or undefined).
+ */
+export const TypographyMarkdown = ({
+  children,
+  ...rest
+}: TypographyMarkdownProps) => {
+  return (
+    <Typography {...rest}>
+      <ReactMarkdown>{children ?? ""}</ReactMarkdown>
+    </Typography>
+  );
+};


### PR DESCRIPTION
When deleting a main activity or choice with children, the warning message will now say:
> This will delete **ALL** the cards below. Are you sure you want to proceed?

Closes #805 